### PR TITLE
added extra two fields for Duo Security device type

### DIFF
--- a/lib/onelogin/api/models/device.rb
+++ b/lib/onelogin/api/models/device.rb
@@ -4,11 +4,13 @@ module OneLogin
 
       class Device
 
-        attr_accessor :id, :type
+        attr_accessor :id, :type, :duo_api_hostname, :duo_sig_request
 
         def initialize(data)
           @id = data['device_id']
           @type = data['device_type'].to_s
+          @duo_api_hostname = data['duo_api_hostname']
+          @duo_sig_request = data['duo_sig_request']
         end
       end
     end


### PR DESCRIPTION
In documentation I have found following:

https://developers.onelogin.com/api-docs/1/login-page/create-session-login-token
When the device type is Duo Security, two additional elements are returned:
* `duo_sig_request`
* `duo_api_hostname`