### PR TITLE
Fix get_event_types

### DIFF
--- a/lib/onelogin/api/client.rb
+++ b/lib/onelogin/api/client.rb
@@ -1057,7 +1057,8 @@ module OneLogin
         begin
         options = {
           model: OneLogin::Api::Models::EventType,
-          headers: authorized_headers
+          headers: authorized_headers,
+          max_results: @max_results
         }
 
         return Cursor.new(url_for(GET_EVENT_TYPES_URL), options)


### PR DESCRIPTION
Add max_results parameter to get_event_types method, otherwise iteration returns an error on the results_remaining method.

Or we should not use cursor on this since there is no pagnation on [API response](https://developers.onelogin.com/api-docs/1/events/event-types).