### PR TITLE
Dont include empty arrays in the results collection

### DIFF
--- a/lib/onelogin/api/cursor.rb
+++ b/lib/onelogin/api/cursor.rb
@@ -56,11 +56,12 @@ class Cursor
     )
 
     json = response.parsed_response
+    results = json['data'].flatten
 
-    @collection += if results_remaining < json['data'].size
-      json['data'].slice(0, results_remaining)
+    @collection += if results_remaining < results.size
+      results.slice(0, results_remaining)
     else
-      json['data']
+      results
     end
 
     @after_cursor = after_cursor(json)


### PR DESCRIPTION
https://github.com/onelogin/onelogin-ruby-sdk/issues/10

For some reason when a collection is empty the OneLogin API returns an array with the first item being an empty array. 

To deal with this we can simply flatten the array before adding it to our cursor. 