### PR TITLE
Allow proxy to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ enroll_factor = client.enroll_factor(user_id, auth_factors.first.id, 'My Device'
 
 # Get Enrolled Authentication Factors
 otp_devices = client.get_enrolled_factors(user_id)
- 
+
 # Activate an Authentication Factor
 device_id = 0000000
 enrollment_response = client.activate_factor(user_id, device_id)
@@ -343,7 +343,7 @@ apps = client.get_embed_apps("30e256c101cd0d2e731de1ec222e93c4be8a1572", "user@e
 ```
 
 ## Proxy Servers
-If you're stuck behind a proxy then you can still use this SDK by providing at a minimum the 
+If you're stuck behind a proxy then you can still use this SDK by providing at a minimum the
 host address of your proxy server.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -342,6 +342,26 @@ embed_token = "30e256c101cd0d2e731de1ec222e93c4be8a1572"
 apps = client.get_embed_apps("30e256c101cd0d2e731de1ec222e93c4be8a1572", "user@example.com")
 ```
 
+## Proxy Servers
+If you're stuck behind a proxy then you can still use this SDK by providing at a minimum the 
+host address of your proxy server.
+
+```ruby
+client = OneLogin::Api::Client.new(
+  client_id: 'some-client-id',
+  client_secret:'some-client-secret',
+  region: 'us',
+  proxy_host: 'https://blah.com',
+  proxy_port: '8080',
+  proxy_user: 'username',
+  proxy_pass: 'password'
+)
+```
+
+* `proxy_host` - required, the host address of your proxy server
+* `proxy_port` - optional, the port number of your proxy server
+* `proxy_user` - optional, the username for your proxy server
+* `proxy_pass` - optional, the password for your proxy server
 
 ## Development
 

--- a/lib/onelogin/api/client.rb
+++ b/lib/onelogin/api/client.rb
@@ -37,6 +37,10 @@ module OneLogin
         @region = options[:region] || 'us'
         @max_results = options[:max_results] || 1000
 
+        if options[:proxy_host]
+          http_proxy options[:proxy_host], options[:proxy_port], options[:proxy_user], options[:proxy_pass]
+        end
+
         validate_config
 
         @user_agent = DEFAULT_USER_AGENT
@@ -62,7 +66,7 @@ module OneLogin
           if status.has_key?('message')
             if status['message'].instance_of?(Hash)
               if status['message'].has_key?('description')
-                message = status['message']['description']  
+                message = status['message']['description']
               end
             else
               message = status['message']
@@ -81,8 +85,8 @@ module OneLogin
           status = content['status']
           if status.has_key?('message') && status['message'].instance_of?(Hash)
             if status['message'].has_key?('attribute')
-              attribute = status['message']['attribute']  
-            end            
+              attribute = status['message']['attribute']
+            end
           end
         end
         attribute

--- a/lib/onelogin/api/client.rb
+++ b/lib/onelogin/api/client.rb
@@ -16,6 +16,7 @@ module OneLogin
   	#
     class Client
       include OneLogin::Api::Util
+      include HTTParty
 
       attr_accessor :client_id, :client_secret, :region
       attr_accessor :user_agent, :error, :error_description, :error_attribute
@@ -38,7 +39,7 @@ module OneLogin
         @max_results = options[:max_results] || 1000
 
         if options[:proxy_host]
-          http_proxy options[:proxy_host], options[:proxy_port], options[:proxy_user], options[:proxy_pass]
+          self.class.http_proxy options[:proxy_host], options[:proxy_port], options[:proxy_user], options[:proxy_pass]
         end
 
         validate_config
@@ -193,7 +194,7 @@ module OneLogin
             'grant_type' => 'client_credentials'
           }
 
-          response = HTTParty.post(
+          response = self.class.post(
             url,
             headers: authorized_headers(false),
             body: data.to_json

--- a/lib/onelogin/api/client.rb
+++ b/lib/onelogin/api/client.rb
@@ -236,7 +236,7 @@ module OneLogin
             'refresh_token' => @refresh_token
           }
 
-          response = HTTParty.post(
+          response = self.class.post(
             url,
             headers: headers,
             body: data.to_json
@@ -276,7 +276,7 @@ module OneLogin
             access_token: @access_token
           }
 
-          response = HTTParty.post(
+          response = self.class.post(
             url,
             headers: authorized_headers(false),
             body: data.to_json
@@ -311,7 +311,7 @@ module OneLogin
         begin
           url = url_for(GET_RATE_URL)
 
-          response = HTTParty.get(
+          response = self.class.get(
             url,
             headers: authorized_headers
           )
@@ -353,7 +353,8 @@ module OneLogin
             model: OneLogin::Api::Models::User,
             headers: authorized_headers,
             max_results: @max_results,
-            params: params
+            params: params,
+            client: self.class
           }
 
           return Cursor.new(url_for(GET_USERS_URL), options)
@@ -381,7 +382,7 @@ module OneLogin
 
           url = url_for(GET_USER_URL, user_id)
 
-          response = HTTParty.get(
+          response = self.class.get(
             url,
             headers: authorized_headers
           )
@@ -445,7 +446,7 @@ module OneLogin
         begin
           url = url_for(GET_ROLES_FOR_USER_URL, user_id)
 
-          response = HTTParty.get(
+          response = self.class.get(
             url,
             headers: authorized_headers
           )
@@ -480,7 +481,7 @@ module OneLogin
         begin
           url = url_for(GET_CUSTOM_ATTRIBUTES_URL)
 
-          response = HTTParty.get(
+          response = self.class.get(
             url,
             headers: authorized_headers
           )
@@ -524,7 +525,7 @@ module OneLogin
         begin
           url = url_for(CREATE_USER_URL)
 
-          response = HTTParty.post(
+          response = self.class.post(
             url,
             headers: authorized_headers,
             body: user_params.to_json
@@ -568,7 +569,7 @@ module OneLogin
         begin
           url = url_for(UPDATE_USER_URL, user_id)
 
-          response = HTTParty.put(
+          response = self.class.put(
             url,
             headers: authorized_headers,
             body: user_params.to_json
@@ -611,7 +612,7 @@ module OneLogin
             'role_id_array' => role_ids
           }
 
-          response = HTTParty.put(
+          response = self.class.put(
             url,
             headers: authorized_headers,
             body: data.to_json
@@ -651,7 +652,7 @@ module OneLogin
             'role_id_array' => role_ids
           }
 
-          response = HTTParty.put(
+          response = self.class.put(
             url,
             headers: authorized_headers,
             body: data.to_json
@@ -695,7 +696,7 @@ module OneLogin
             'validate_policy' => validate_policy
           }
 
-          response = HTTParty.put(
+          response = self.class.put(
             url,
             headers: authorized_headers,
             body: data.to_json
@@ -744,7 +745,7 @@ module OneLogin
             data['password_salt'] = password_salt
           end
 
-          response = HTTParty.put(
+          response = self.class.put(
             url,
             headers: authorized_headers,
             body: data.to_json
@@ -784,7 +785,7 @@ module OneLogin
             'state' => state
           }
 
-          response = HTTParty.put(
+          response = self.class.put(
             url,
             headers: authorized_headers,
             body: data.to_json
@@ -824,7 +825,7 @@ module OneLogin
             'custom_attributes' => custom_attributes
           }
 
-          response = HTTParty.put(
+          response = self.class.put(
             url,
             headers: authorized_headers,
             body: data.to_json
@@ -859,7 +860,7 @@ module OneLogin
         begin
           url = url_for(LOG_USER_OUT_URL, user_id)
 
-          response = HTTParty.put(
+          response = self.class.put(
             url,
             headers: authorized_headers
           )
@@ -900,7 +901,7 @@ module OneLogin
             'locked_until' => minutes
           }
 
-          response = HTTParty.put(
+          response = self.class.put(
             url,
             headers: authorized_headers,
             body: data.to_json
@@ -935,7 +936,7 @@ module OneLogin
         begin
           url = url_for(DELETE_USER_URL, user_id)
 
-          response = HTTParty.delete(
+          response = self.class.delete(
             url,
             headers: authorized_headers
           )
@@ -978,7 +979,7 @@ module OneLogin
             raise "username_or_email, password and subdomain are required parameters"
           end
 
-          response = HTTParty.post(
+          response = self.class.post(
             url,
             headers: authorized_headers.merge({ 'Custom-Allowed-Origin-Header-1' => allowed_origin }),
             body: query_params.to_json
@@ -1023,7 +1024,7 @@ module OneLogin
             data['otp_token'] = otp_token
           end
 
-          response = HTTParty.post(
+          response = self.class.post(
             url,
             headers: authorized_headers.merge({ 'Custom-Allowed-Origin-Header-1' => allowed_origin }),
             body: data.to_json
@@ -1091,7 +1092,7 @@ module OneLogin
         begin
           url = url_for(GET_ROLE_URL, role_id)
 
-          response = HTTParty.get(
+          response = self.class.get(
             url,
             headers: authorized_headers
           )
@@ -1186,7 +1187,7 @@ module OneLogin
         begin
           url = url_for(GET_EVENT_URL, event_id)
 
-          response = HTTParty.get(
+          response = self.class.get(
             url,
             headers: authorized_headers
           )
@@ -1228,7 +1229,7 @@ module OneLogin
         begin
           url = url_for(CREATE_EVENT_URL)
 
-          response = HTTParty.post(
+          response = self.class.post(
             url,
             headers: authorized_headers,
             body: event_params.to_json
@@ -1294,7 +1295,7 @@ module OneLogin
         begin
           url = url_for(GET_GROUP_URL, group_id)
 
-          response = HTTParty.get(
+          response = self.class.get(
             url,
             headers: authorized_headers
           )
@@ -1349,7 +1350,7 @@ module OneLogin
             data['ip_address'] = ip_address
           end
 
-          response = HTTParty.post(
+          response = self.class.post(
             url,
             headers: authorized_headers,
             body: data.to_json
@@ -1402,7 +1403,7 @@ module OneLogin
             data['otp_token'] = otp_token
           end
 
-          response = HTTParty.post(
+          response = self.class.post(
             url,
             headers: authorized_headers,
             body: data.to_json
@@ -1440,7 +1441,7 @@ module OneLogin
         begin
           url = url_for(GET_FACTORS_URL, user_id)
 
-          response = HTTParty.get(
+          response = self.class.get(
             url,
             :headers => authorized_headers
           )
@@ -1489,7 +1490,7 @@ module OneLogin
             'number'=> number
           }
 
-          response = HTTParty.post(
+          response = self.class.post(
             url,
             :headers => authorized_headers,
             body: data.to_json
@@ -1526,7 +1527,7 @@ module OneLogin
         begin
           url = url_for(GET_ENROLLED_FACTORS_URL, user_id)
 
-          response = HTTParty.get(
+          response = self.class.get(
             url,
             :headers => authorized_headers
           )
@@ -1568,7 +1569,7 @@ module OneLogin
         begin
           url = url_for(ACTIVATE_FACTOR_URL, user_id, device_id)
 
-          response = HTTParty.post(
+          response = self.class.post(
             url,
             headers: authorized_headers
           )
@@ -1625,7 +1626,7 @@ module OneLogin
             data['state_token'] = state_token
           end
 
-          response = HTTParty.post(
+          response = self.class.post(
             url,
             headers: authorized_headers,
             body: data.to_json
@@ -1660,7 +1661,7 @@ module OneLogin
         begin
           url = url_for(REMOVE_FACTOR_URL, user_id, device_id)
 
-          response = HTTParty.delete(
+          response = self.class.delete(
             url,
             :headers => authorized_headers
           )
@@ -1702,7 +1703,7 @@ module OneLogin
             'email'=> email
           }
 
-          response = HTTParty.post(
+          response = self.class.post(
             url,
             headers: authorized_headers,
             body: data.to_json
@@ -1750,7 +1751,7 @@ module OneLogin
             data['personal_email'] = personal_email
           end
 
-          response = HTTParty.post(
+          response = self.class.post(
             url,
             headers: authorized_headers,
             body: data.to_json
@@ -1782,7 +1783,7 @@ module OneLogin
         clean_error
 
         begin
-          response = HTTParty.get(
+          response = self.class.get(
             EMBED_APP_URL,
             headers: {
               'User-Agent' => @user_agent

--- a/lib/onelogin/api/cursor.rb
+++ b/lib/onelogin/api/cursor.rb
@@ -19,6 +19,7 @@ class Cursor
     @headers = options[:headers] || {}
     @params = options[:params] || {}
     @max_results = options[:max_results]
+    @client = options[:client]
 
     @collection = []
     @after_cursor = options.fetch(:after_cursor, nil)
@@ -49,7 +50,7 @@ class Cursor
   def fetch_next_page
     @params = @params.merge(after_cursor: @after_cursor) if @after_cursor
 
-    response = HTTParty.get(
+    response = @client.get(
       @url,
       headers: @headers,
       query: @params


### PR DESCRIPTION
Some users need to run requests via a proxy. 

This PR lets the client be instantiated with additional proxy settings. 

```ruby
client = OneLogin::Api::Client.new(
  client_id: 'some-client-id',
  client_secret:'some-client-secret',
  region: 'us',
  proxy_host: 'https://blah.com',
  proxy_port: '8080',
  proxy_user: 'username',
  proxy_pass: 'password'
)
```

Minimum requirement is that `proxy_host` is supplied. All other proxy attributes are optional. 