### PR TITLE
HTTP client was not getting passed to cursor

### DIFF
--- a/lib/onelogin/api/client.rb
+++ b/lib/onelogin/api/client.rb
@@ -353,11 +353,10 @@ module OneLogin
             model: OneLogin::Api::Models::User,
             headers: authorized_headers,
             max_results: @max_results,
-            params: params,
-            client: self.class
+            params: params
           }
 
-          return Cursor.new(url_for(GET_USERS_URL), options)
+          return Cursor.new(self.class, url_for(GET_USERS_URL), options)
 
         rescue Exception => e
           @error = '500'
@@ -422,7 +421,7 @@ module OneLogin
             max_results: @max_results
           }
 
-          return Cursor.new(url_for(GET_APPS_FOR_USER_URL, user_id), options)
+          return Cursor.new(self.class, url_for(GET_APPS_FOR_USER_URL, user_id), options)
 
         rescue Exception => e
           @error = '500'
@@ -1081,7 +1080,7 @@ module OneLogin
             params: params
           }
 
-          return Cursor.new(url_for(GET_ROLES_URL), options)
+          return Cursor.new(self.class, url_for(GET_ROLES_URL), options)
 
         rescue Exception => e
           @error = '500'
@@ -1147,7 +1146,7 @@ module OneLogin
           max_results: @max_results
         }
 
-        return Cursor.new(url_for(GET_EVENT_TYPES_URL), options)
+        return Cursor.new(self.class, url_for(GET_EVENT_TYPES_URL), options)
 
         rescue Exception => e
           @error = '500'
@@ -1176,7 +1175,7 @@ module OneLogin
           params: params
         }
 
-        return Cursor.new(url_for(GET_EVENTS_URL), options)
+        return Cursor.new(self.class, url_for(GET_EVENTS_URL), options)
 
         rescue Exception => e
           @error = '500'
@@ -1284,7 +1283,7 @@ module OneLogin
             params: params
           }
 
-          return Cursor.new(url_for(GET_GROUPS_URL), options)
+          return Cursor.new(self.class, url_for(GET_GROUPS_URL), options)
 
         rescue Exception => e
           @error = '500'

--- a/lib/onelogin/api/cursor.rb
+++ b/lib/onelogin/api/cursor.rb
@@ -11,7 +11,8 @@ class Cursor
   # @param url [String] The url of the API endpoint
   # @param options [Hash] Configuation options
   #
-  def initialize(url, options = {})
+  def initialize(client, url, options = {})
+    @client = client
     @url = url
     @options = options
 
@@ -19,7 +20,6 @@ class Cursor
     @headers = options[:headers] || {}
     @params = options[:params] || {}
     @max_results = options[:max_results]
-    @client = options[:client]
 
     @collection = []
     @after_cursor = options.fetch(:after_cursor, nil)
@@ -57,6 +57,7 @@ class Cursor
     )
 
     json = response.parsed_response
+
     results = json['data'].flatten
 
     @collection += if results_remaining < results.size


### PR DESCRIPTION
There is a bug introduced in v1.2.2 of this gem where the HTTParty client is not injected into the cursor. 

I moved this from being option to a requirement when instantiating the cursor. 