### PR TITLE
Raise error if parsed response is a string

### DIFF
--- a/lib/onelogin/api/cursor.rb
+++ b/lib/onelogin/api/cursor.rb
@@ -66,6 +66,8 @@ class Cursor
 
     if json.nil?
       raise OneLogin::Api::ApiException.new("Response could not be parsed", 500)
+    elsif json.is_a?(String)
+      raise OneLogin::Api::ApiException.new(response.message, response.code)
     elsif !json.has_key?(@container) && json.has_key?('status') && json["status"]["error"] == true
       raise OneLogin::Api::ApiException.new(extract_error_message_from_response(response), json["status"]["code"])
     elsif !json.has_key?(@container) && json.has_key?('statusCode')


### PR DESCRIPTION
It's currently possible for the parsed response from `fetch_next_page` to be a string instead of a hash.

In one scenario, when the server returns a 504 gateway timeout, it will return an HTML string instead of a hash and attempt to call `has_key?` on the string:

```console
Traceback (most recent call last):
	12: from recreate_bug.rb:15:in `<main>'
	11: from /Users/zacblazic/workspace/personal/onelogin-ruby-sdk/lib/onelogin/api/cursor.rb:49:in `each'
	10: from /Users/zacblazic/workspace/personal/onelogin-ruby-sdk/lib/onelogin/api/cursor.rb:49:in `each'
	 9: from /Users/zacblazic/workspace/personal/onelogin-ruby-sdk/lib/onelogin/api/cursor.rb:49:in `each'
	 8: from /Users/zacblazic/workspace/personal/onelogin-ruby-sdk/lib/onelogin/api/cursor.rb:49:in `each'
	 7: from /Users/zacblazic/workspace/personal/onelogin-ruby-sdk/lib/onelogin/api/cursor.rb:49:in `each'
	 6: from /Users/zacblazic/workspace/personal/onelogin-ruby-sdk/lib/onelogin/api/cursor.rb:36:in `each'
	 5: from /Users/zacblazic/workspace/personal/onelogin-ruby-sdk/lib/onelogin/api/cursor.rb:36:in `each'
	 4: from /Users/zacblazic/workspace/personal/onelogin-ruby-sdk/lib/onelogin/api/cursor.rb:38:in `block in each'
	 3: from recreate_bug.rb:17:in `block in <main>'
	 2: from recreate_bug.rb:17:in `to_a'
	 1: from /Users/zacblazic/workspace/personal/onelogin-ruby-sdk/lib/onelogin/api/cursor.rb:47:in `each'
/Users/zacblazic/workspace/personal/onelogin-ruby-sdk/lib/onelogin/api/cursor.rb:69:in `fetch_next_page': undefined method `has_key?' for #<String:0x00007fa4baa1dfe0> (NoMethodError)
```

My changes aim to handle this edge case and raise an exception with the underlying HTTP response message and code:

```console
Traceback (most recent call last):
	8: from recreate_bug.rb:15:in `<main>'
	7: from /Users/zacblazic/workspace/personal/onelogin-ruby-sdk/lib/onelogin/api/cursor.rb:49:in `each'
	6: from /Users/zacblazic/workspace/personal/onelogin-ruby-sdk/lib/onelogin/api/cursor.rb:36:in `each'
	5: from /Users/zacblazic/workspace/personal/onelogin-ruby-sdk/lib/onelogin/api/cursor.rb:36:in `each'
	4: from /Users/zacblazic/workspace/personal/onelogin-ruby-sdk/lib/onelogin/api/cursor.rb:38:in `block in each'
	3: from recreate_bug.rb:17:in `block in <main>'
	2: from recreate_bug.rb:17:in `to_a'
	1: from /Users/zacblazic/workspace/personal/onelogin-ruby-sdk/lib/onelogin/api/cursor.rb:47:in `each'
/Users/zacblazic/workspace/personal/onelogin-ruby-sdk/lib/onelogin/api/cursor.rb:70:in `fetch_next_page': Gateway Time-out (OneLogin::Api::ApiException)
```