### PR TITLE
Fix events to csv example results limit

### DIFF
--- a/examples/events-to-csv.rb
+++ b/examples/events-to-csv.rb
@@ -52,11 +52,15 @@ OptionParser.new do |opts|
   end
 end.parse!
 
+counter = 0
+limit = options[:limit] || 1000
+
 # Fetch the events
 client = OneLogin::Api::Client.new(
   client_id: 'ONELOGIN_CLIENT_ID_GOES_HERE',
   client_secret: 'ONELOGIN_CLIENT_SECRET_GOES_HERE',
-  region: 'us'
+  region: 'us',
+  max_results: limit
 )
 
 attribute_names = ['id', 'created_at', 'account_id', 'user_id', 'user_name', 'event_type_id',
@@ -65,9 +69,6 @@ attribute_names = ['id', 'created_at', 'account_id', 'user_id', 'user_name', 'ev
                   'otp_device_name', 'policy_id', 'policy_name', 'actor_system', 'custom_message',
                   'operation_name', 'directory_sync_run_id', 'directory_id', 'resolution', 'client_id',
                   'resource_type_id', 'error_description', 'risk_score', 'risk_reasons', 'risk_cookie_id', 'browser_fingerprint']
-
-counter = 0
-limit = options[:limit] || 1000
 
 # We remove limit from options parsed to the api as we want to fetch
 # the max number of records possible and then use the cursor that is


### PR DESCRIPTION
Fixed sample code limiting number of events option not working.