### PR TITLE
DOCS-1137: Adding support disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ The toolkit is hosted on github. You can download it from:
 * Master repo: https://github.com/onelogin/onelogin-ruby-sdk/tree/master
 
 
+## Support
+
+OneLogin by One Identity open source projects are supported through [OneLogin GitHub issues](https://github.com/onelogin/onelogin-ruby-sdk/issues). This includes all scripts, plugins, SDKs, modules, code snippets or other solutions. For assistance with any OneLogin by One Identity GitHub project, please raise a new Issue on the [OneLogin GitHub issues](https://github.com/onelogin/onelogin-ruby-sdk/issues) page. Requests for assistance made through official One Identity Support will be referred back to GitHub where those requests can benefit all users.
+
+
+
 ## Installation
 
 Add this line to your application's Gemfile:


### PR DESCRIPTION
This pull request includes an update to the README.md file to provide information on how to get support for OneLogin open source projects.

Documentation update:

README.md: Added a new "Support" section that directs users to the OneLogin GitHub issues page for assistance with scripts, plugins, SDKs, modules, code snippets, or other solutions.