### PR TITLE
Release 1.7.0

### DIFF
--- a/lib/onelogin/version.rb
+++ b/lib/onelogin/version.rb
@@ -1,3 +1,3 @@
 module OneLogin
-  VERSION = "1.6.0"
+  VERSION = "1.7.0"
 end


### PR DESCRIPTION
Bumps `lib/onelogin/version.rb` to 1.7.0 so the fix from #109 can be published to RubyGems.

**Minor, not patch** — #109 added `token_expiration_buffer` as a new public config option. Additive and backward-compatible, so 1.7.0 under semver.

### What ships

Everything on `master` since `v1.6.0` (Jan 2022) is #109 and nothing else, so this release carries exactly one change:

- Proactive token refresh via a configurable `token_expiration_buffer` (default 30s), so a token that would lapse mid-request is refreshed first
- `prepare_token` falls back to `access_token` when the refresh grant fails, instead of silently reusing the stale token and returning 401
- `expired?` no longer raises when no expiration has been recorded
- `token_expiration_buffer` validated as a non-negative integer at construction

### Release is manual

This repo has no publish workflow — the only workflows are `git-secrets` and `test`. Creating a GitHub Release triggers nothing. After this merges, publishing is:

```
gem build onelogin.gemspec
gem push onelogin-1.7.0.gem      # needs onelogin-devex credentials
git tag -a v1.7.0 -m "Release 1.7.0" && git push origin v1.7.0
```

Worth adding a tag-triggered workflow with RubyGems trusted publishing afterwards so the next release isn't gated on one person's API key.