### PR TITLE
Remove dead .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 1.9.3
-  - 2.4.1
-before_install: gem install bundler -v 1.15.3


### PR DESCRIPTION
Deletes `.travis.yml`. Salvaged from #106, which was otherwise superseded by the `test.yml` workflow added in #109 and has since been closed.

### Why

The config has been inert for years and could not work if it ran:

```yaml
rvm:
  - 1.9.3
  - 2.4.1
before_install: gem install bundler -v 1.15.3
```

Travis CI no longer builds this repo, and the current dependency set doesn't resolve on either Ruby version — modern `nokogiri` needs >= 3.0 and `webmock` won't install on 2.4. Keeping it around just implies a CI path that doesn't exist.

### Current CI

`.github/workflows/test.yml` runs the spec suite on Ruby 3.0–3.3, plus `git-secrets`. Nothing references `.travis.yml` — no badge, no docs, no scripts.