### PR TITLE
Bump rake dev dependency to ~> 13.0

### DIFF
--- a/onelogin.gemspec
+++ b/onelogin.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('nokogiri', '>=1.6.3.1')
 
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 3.0"
 end


### PR DESCRIPTION
Changes `spec.add_development_dependency "rake"` from `~> 10.0` to `~> 13.0`.

### Why

This is the **only** open Dependabot alert against the SDK itself — every other one is in the example apps.

| | |
|---|---|
| Advisory | [GHSA-jppv-gw3r-w3q8](https://github.com/advisories/GHSA-jppv-gw3r-w3q8) — OS command injection in Rake |
| Severity | Medium |
| Vulnerable | `<= 12.3.2` |
| Patched in | `12.3.3` |

The `~> 10.0` pin caps at rake 10.x, so the alert could never be resolved without changing the constraint.

**Practical risk is low** — it's a development dependency, invisible to gem consumers, and exploiting it requires feeding untrusted filenames to `Rake::FileList`. But it costs one line to clear, and leaving it means the SDK's own alert count never reaches zero.

### Verification

```
rake (13.4.2)
bundle exec rake spec   -> 24 examples, 0 failures
bundle exec rake -T     -> build/install/release tasks intact
```

`bundler/gem_tasks` still loads, so the `rake release` path used for publishing is unaffected.