### PR TITLE
Regenerate examples/Gemfile.lock

### DIFF
--- a/examples/Gemfile.lock
+++ b/examples/Gemfile.lock
@@ -1,19 +1,23 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    httparty (0.18.0)
-      mime-types (~> 3.0)
+    bigdecimal (4.1.2)
+    csv (3.3.6)
+    httparty (0.24.2)
+      csv
+      mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    mime-types (3.3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.0425)
-    mini_portile2 (2.4.0)
-    multi_xml (0.6.0)
-    nokogiri (1.10.9)
-      mini_portile2 (~> 2.4.0)
-    onelogin (1.6.0)
+    mini_mime (1.1.5)
+    mini_portile2 (2.8.9)
+    multi_xml (0.9.1)
+      bigdecimal (>= 3.1, < 5)
+    nokogiri (1.19.4)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    onelogin (1.7.0)
       httparty (>= 0.13.7)
       nokogiri (>= 1.6.3.1)
+    racc (1.8.1)
 
 PLATFORMS
   ruby
@@ -22,4 +26,4 @@ DEPENDENCIES
   onelogin
 
 BUNDLED WITH
-   2.1.4
+   2.6.9


### PR DESCRIPTION
Refreshes `examples/Gemfile.lock`, untouched since 2020. Clears the 36 remaining Dependabot alerts on the example scripts.

### Before → after

| Gem | Was | Now |
|---|---|---|
| `onelogin` | 1.6.0 | **1.7.0** |
| `httparty` | 0.18.0 | 0.24.2 |
| `nokogiri` | 1.10.9 | 1.19.4 |
| `multi_xml` | 0.6.0 | 0.9.1 |

### Resolved under Ruby 3.4.1, deliberately

Resolving on Ruby 3.0 caps nokogiri at **1.17.2**, which still carries a **critical** advisory ([GHSA-353f-x4gh-cqq8](https://github.com/advisories/GHSA-353f-x4gh-cqq8), needs ≥ 1.18.9) plus a high (≥ 1.19.3) — nokogiri 1.18+ requires Ruby ≥ 3.1. Generating under 3.4.1 reaches 1.19.4 and clears all of them.

`PLATFORMS` stays `ruby` rather than gaining a platform-specific entry, so the lock is still portable across platforms.

### Verification

Every resolved gem checked against the GitHub Advisory Database:

```
checked 9 gems: bigdecimal 4.1.2, csv 3.3.6, httparty 0.24.2, mini_mime 1.1.5,
mini_portile2 2.8.9, multi_xml 0.9.1, nokogiri 1.19.4, onelogin 1.7.0, racc 1.8.1

no known advisories against any resolved version
```

This is a lockfile for example scripts only — it has no effect on the published gem's dependency resolution, which is governed by the `>=` constraints in `onelogin.gemspec`.

### Follow-up

Retires the last two Dependabot PRs, both of which target versions now behind this lock: #95 (httparty → 0.21.0) and #102 (nokogiri → 1.14.3).