### PR TITLE
Detect non-200 responses on paginated endpoints

### DIFF
--- a/lib/onelogin/api/apiexception.rb
+++ b/lib/onelogin/api/apiexception.rb
@@ -1,6 +1,9 @@
 module OneLogin
   module Api
     class ApiException < Exception
+      # HTTP status (or API status code) the exception was raised for.
+      attr_reader :code
+
       def initialize(message, code)
         super(message)
         @code = code

--- a/lib/onelogin/api/cursor.rb
+++ b/lib/onelogin/api/cursor.rb
@@ -64,8 +64,11 @@ class Cursor
 
     json = response.parsed_response
 
-    if json.nil?
-      raise OneLogin::Api::ApiException.new("Response could not be parsed", 500)
+    # HTTParty picks its parser from Content-Type, so a gateway or proxy error
+    # page comes back as a String and every has_key? below would blow up with a
+    # NoMethodError instead of a usable ApiException.
+    if json.nil? || !json.is_a?(Hash)
+      raise OneLogin::Api::ApiException.new("Response could not be parsed", response.code)
     elsif !json.has_key?(@container) && json.has_key?('status') && json["status"]["error"] == true
       raise OneLogin::Api::ApiException.new(extract_error_message_from_response(response), json["status"]["code"])
     elsif !json.has_key?(@container) && json.has_key?('statusCode')

--- a/spec/lib/onelogin/api/cursor_spec.rb
+++ b/spec/lib/onelogin/api/cursor_spec.rb
@@ -1,0 +1,78 @@
+require "spec_helper"
+
+RSpec.describe Cursor do
+  let(:users_url) { "https://api.us.onelogin.com/api/1/users" }
+  let(:json_headers) { { 'Content-Type' => 'application/json' } }
+
+  let(:client) do
+    OneLogin::Api::Client.new(client_id: 'test_id', client_secret: 'test_secret')
+  end
+
+  # Seed a live token so the cursor doesn't try to fetch one.
+  before do
+    client.instance_variable_set(:@access_token, 'test_token')
+    client.instance_variable_set(:@refresh_token, 'test_refresh')
+    client.instance_variable_set(:@expiration, Time.now.utc + 3600)
+  end
+
+  def stub_users(status:, body:, headers: json_headers)
+    stub_request(:get, users_url).to_return(status: status, body: body, headers: headers)
+  end
+
+  def error_body(code, type, message)
+    { status: { error: true, code: code, type: type, message: message } }.to_json
+  end
+
+  describe 'error responses from a paginated endpoint' do
+    it 'raises ApiException on a 401' do
+      stub_users(status: 401, body: error_body(401, 'Unauthorized', 'Authentication Failure'))
+
+      expect { client.get_users.to_a }
+        .to raise_error(OneLogin::Api::ApiException) { |e| expect(e.code).to eq(401) }
+    end
+
+    it 'raises ApiException on a 400' do
+      stub_users(status: 400, body: error_body(400, 'bad request', 'Invalid parameter'))
+
+      expect { client.get_users.to_a }
+        .to raise_error(OneLogin::Api::ApiException) { |e| expect(e.code).to eq(400) }
+    end
+
+    it 'raises ApiException on an empty body' do
+      stub_users(status: 401, body: '')
+
+      expect { client.get_users.to_a }.to raise_error(OneLogin::Api::ApiException)
+    end
+
+    # HTTParty parses by Content-Type, so a proxy/load-balancer error page comes
+    # back as a String. Before this guard that raised NoMethodError on has_key?.
+    it 'raises ApiException on a non-JSON error page' do
+      stub_users(status: 502, body: '<html>502 Bad Gateway</html>',
+                 headers: { 'Content-Type' => 'text/html' })
+
+      expect { client.get_users.to_a }
+        .to raise_error(OneLogin::Api::ApiException) { |e| expect(e.code).to eq(502) }
+    end
+
+    it 'reports the real HTTP status rather than a fabricated 500' do
+      stub_users(status: 503, body: 'upstream unavailable',
+                 headers: { 'Content-Type' => 'text/plain' })
+
+      expect { client.get_users.to_a }
+        .to raise_error(OneLogin::Api::ApiException) { |e| expect(e.code).to eq(503) }
+    end
+  end
+
+  describe 'successful responses' do
+    it 'still yields models on a 200' do
+      stub_users(status: 200, body: { status: { error: false, code: 200 },
+                                      data: [{ id: 1, username: 'alice' },
+                                             { id: 2, username: 'bob' }] }.to_json)
+
+      users = client.get_users.to_a
+
+      expect(users.size).to eq(2)
+      expect(users.map(&:username)).to eq(%w[alice bob])
+    end
+  end
+end


### PR DESCRIPTION
Fixes #4 (open since 2017).

### The bug

`Cursor#fetch_next_page` does:

```ruby
json = response.parsed_response
if json.nil?
  raise ApiException.new("Response could not be parsed", 500)
elsif !json.has_key?(@container) && ...
```

HTTParty picks its parser from `Content-Type`. A proxy or load-balancer error page comes back as `text/html`, so `parsed_response` returns a **String** and `has_key?` explodes:

```
NoMethodError: undefined method `has_key?' for "<html>502 Bad Gateway</html>":String
```

The caller gets a `NoMethodError` from deep inside the SDK instead of a usable `ApiException`.

### `ApiException#code` was unreadable

```ruby
class ApiException < Exception
  def initialize(message, code)
    super(message)
    @code = code      # stored, never exposed
  end
end
```

Issue #4 is literally *"How detect HTTP RESPONSES different than 200"* — and the exception carried the status but offered no way to read it. Added `attr_reader :code`.

### Real status instead of a fabricated 500

The unparseable branch hardcoded `500`. It now passes `response.code`, so a 502 reports 502.

### Verification

First spec coverage `Cursor` has ever had — 6 examples covering 401, 400, empty body, non-JSON error page, real-status reporting, and that the 200 path still maps models.

Against `master`, **4 of the 6 fail**; with the fix, all pass. Full suite: 30 examples, 0 failures.

### Worth noting separately

`ApiException < Exception` rather than `StandardError`, so a bare `rescue` or `rescue => e` will not catch it — callers must name the class explicitly. That is a surprising default, but changing it alters catch behaviour for existing consumers, so I have left it alone here.