### PR TITLE
Accept symbol keys in parameter hashes; repair create_app guard

### DIFF
--- a/lib/onelogin/api/client.rb
+++ b/lib/onelogin/api/client.rb
@@ -66,8 +66,17 @@ module OneLogin
       # checks below look them up as strings. `to_json` already serializes both
       # forms identically, so only the validation ever disagreed.
       #
+      # Anything that isn't a Hash becomes an empty one so the required-parameter
+      # guards still fire and report the missing attribute, rather than blowing
+      # up on has_key? and surfacing as a generic 500.
+      #
+      # An already-string-keyed hash is returned untouched, so existing callers
+      # keep the exact object they passed - including Hash subclasses with their
+      # own to_json.
+      #
       def stringify_param_keys(params)
-        return params unless params.is_a?(Hash)
+        return {} unless params.is_a?(Hash)
+        return params if params.keys.all? { |key| key.is_a?(String) }
 
         params.each_with_object({}) { |(key, value), out| out[key.to_s] = value }
       end

--- a/lib/onelogin/api/client.rb
+++ b/lib/onelogin/api/client.rb
@@ -60,6 +60,19 @@ module OneLogin
         raise ArgumentError, 'client_id & client_secret are required' unless @client_id && @client_secret
       end
 
+      # Normalize caller-supplied parameter hashes to string keys.
+      #
+      # The README and examples use symbol keys, but the required-parameter
+      # checks below look them up as strings. `to_json` already serializes both
+      # forms identically, so only the validation ever disagreed.
+      #
+      def stringify_param_keys(params)
+        return params unless params.is_a?(Hash)
+
+        params.each_with_object({}) { |(key, value), out| out[key.to_s] = value }
+      end
+      private :stringify_param_keys
+
       # Coerce the configured refresh buffer into a non-negative Integer.
       #
       # ENV-backed configs hand this over as a String, and a negative buffer
@@ -1141,6 +1154,8 @@ module OneLogin
         begin
           url = url_for(SESSION_LOGIN_TOKEN_URL)
 
+          query_params = stringify_param_keys(query_params)
+
           if query_params.nil? || !query_params.has_key?('username_or_email') || !query_params.has_key?('password') || !query_params.has_key?('subdomain')
             raise "username_or_email, password and subdomain are required parameters"
           end
@@ -1366,7 +1381,12 @@ module OneLogin
         begin
           url = url_for(CREATE_APP_URL)
 
-          unless app_params.has_key?('connector_id') || app_params['connector_id'].to_s.empty?
+          app_params = stringify_param_keys(app_params)
+
+          # Was `unless has_key? || value.empty?`, which is true in every case,
+          # so the check never fired and an app could be created with no
+          # connector_id at all.
+          if !app_params.has_key?('connector_id') || app_params['connector_id'].to_s.empty?
             @error = '400'
             @error_description = "connector_id is required"
             @error_attribute = "connector_id"

--- a/spec/lib/onelogin/api/param_keys_spec.rb
+++ b/spec/lib/onelogin/api/param_keys_spec.rb
@@ -1,0 +1,104 @@
+require "spec_helper"
+
+RSpec.describe "Caller-supplied parameter hashes" do
+  let(:client) do
+    OneLogin::Api::Client.new(client_id: 'test_id', client_secret: 'test_secret')
+  end
+
+  before do
+    client.instance_variable_set(:@access_token, 'test_token')
+    client.instance_variable_set(:@refresh_token, 'test_refresh')
+    client.instance_variable_set(:@expiration, Time.now.utc + 3600)
+  end
+
+  describe '#create_session_login_token' do
+    let(:url) { 'https://api.us.onelogin.com/api/1/login/auth' }
+    let(:success_body) do
+      { status: { error: false, code: 200, type: 'success', message: 'Success' },
+        data: [{ status: 'Authenticated', user: { id: 1, username: 'alice' },
+                 session_token: 'tok', return_to_url: nil, expires_at: '2026-01-01T00:00:00Z' }] }.to_json
+    end
+
+    # Issue #59: the README and examples use symbol keys, but the required
+    # parameter check looked them up as strings and rejected them.
+    it 'accepts symbol keys' do
+      request = stub_request(:post, url)
+        .to_return(status: 200, body: success_body, headers: { 'Content-Type' => 'application/json' })
+
+      client.create_session_login_token(
+        username_or_email: 'user@example.com',
+        password: 'secret',
+        subdomain: 'example'
+      )
+
+      expect(request).to have_been_made
+      expect(client.error).to be_nil
+    end
+
+    it 'still accepts string keys' do
+      request = stub_request(:post, url)
+        .to_return(status: 200, body: success_body, headers: { 'Content-Type' => 'application/json' })
+
+      client.create_session_login_token(
+        'username_or_email' => 'user@example.com',
+        'password' => 'secret',
+        'subdomain' => 'example'
+      )
+
+      expect(request).to have_been_made
+      expect(client.error).to be_nil
+    end
+
+    it 'serializes symbol and string keys to the same body' do
+      bodies = []
+      stub_request(:post, url).to_return do |req|
+        bodies << req.body
+        { status: 200, body: success_body, headers: { 'Content-Type' => 'application/json' } }
+      end
+
+      client.create_session_login_token(username_or_email: 'u', password: 'p', subdomain: 's')
+      client.create_session_login_token('username_or_email' => 'u', 'password' => 'p', 'subdomain' => 's')
+
+      expect(bodies.uniq.size).to eq(1)
+    end
+
+    it 'still rejects a genuinely incomplete hash' do
+      expect { client.create_session_login_token(username_or_email: 'u') }
+        .not_to raise_error
+
+      expect(client.error).to eq('500')
+      expect(client.error_description).to match(/required parameters/)
+    end
+  end
+
+  describe '#create_app' do
+    let(:url) { 'https://api.us.onelogin.com/api/2/apps' }
+
+    # The guard read `unless has_key? || value.empty?`, which is true in every
+    # case, so it never fired.
+    it 'rejects a missing connector_id' do
+      client.create_app({})
+
+      expect(client.error).to eq('400')
+      expect(client.error_attribute).to eq('connector_id')
+    end
+
+    it 'rejects an empty connector_id' do
+      client.create_app('connector_id' => '')
+
+      expect(client.error).to eq('400')
+      expect(client.error_attribute).to eq('connector_id')
+    end
+
+    it 'accepts a symbol-keyed connector_id' do
+      request = stub_request(:post, url)
+        .to_return(status: 201, body: { id: 1, name: 'app', connector_id: 123 }.to_json,
+                   headers: { 'Content-Type' => 'application/json' })
+
+      client.create_app(connector_id: 123, name: 'app')
+
+      expect(request).to have_been_made
+      expect(client.error).to be_nil
+    end
+  end
+end

--- a/spec/lib/onelogin/api/param_keys_spec.rb
+++ b/spec/lib/onelogin/api/param_keys_spec.rb
@@ -49,6 +49,23 @@ RSpec.describe "Caller-supplied parameter hashes" do
       expect(client.error).to be_nil
     end
 
+    # A string-keyed hash is passed through untouched, so callers using a Hash
+    # subclass with its own to_json keep the object they handed us.
+    it 'leaves an already-string-keyed hash untouched' do
+      params = { 'username_or_email' => 'u', 'password' => 'p', 'subdomain' => 's' }
+      seen = nil
+
+      stub_request(:post, url).to_return do |req|
+        seen = req.body
+        { status: 200, body: success_body, headers: { 'Content-Type' => 'application/json' } }
+      end
+
+      expect(client.send(:stringify_param_keys, params)).to equal(params)
+
+      client.create_session_login_token(params)
+      expect(seen).to eq(params.to_json)
+    end
+
     it 'serializes symbol and string keys to the same body' do
       bodies = []
       stub_request(:post, url).to_return do |req|
@@ -85,6 +102,20 @@ RSpec.describe "Caller-supplied parameter hashes" do
 
     it 'rejects an empty connector_id' do
       client.create_app('connector_id' => '')
+
+      expect(client.error).to eq('400')
+      expect(client.error_attribute).to eq('connector_id')
+    end
+
+    it 'rejects nil with the connector_id error rather than a generic 500' do
+      client.create_app(nil)
+
+      expect(client.error).to eq('400')
+      expect(client.error_attribute).to eq('connector_id')
+    end
+
+    it 'rejects a non-Hash argument the same way' do
+      client.create_app('connector_id=123')
 
       expect(client.error).to eq('400')
       expect(client.error_attribute).to eq('connector_id')


### PR DESCRIPTION
Fixes #59 (open since 2020, with a "we gonna fix this on the next release" that never landed).

### Symbol keys were rejected

The README and examples show symbol keys:

```ruby
session_login_token_params = {
  username_or_email: "user@example.com",
  password: "secret",
  subdomain: "example"
}
```

But the guard looks them up as strings:

```ruby
if query_params.nil? || !query_params.has_key?('username_or_email') || ...
  raise "username_or_email, password and subdomain are required parameters"
```

`{username_or_email: 'x'}.has_key?('username_or_email')` is `false`, so the documented call always raised.

The telling part: **`to_json` serializes both forms identically.**

```
{username_or_email: "u"}.to_json == {"username_or_email" => "u"}.to_json  # => true
```

The wire format was never wrong — only the validation disagreed. Fixed by normalizing keys before the check, so both forms work and the request body is unchanged.

### `create_app`'s validation never fired

Separate bug found while fixing the above:

```ruby
unless app_params.has_key?('connector_id') || app_params['connector_id'].to_s.empty?
```

That is true in every case, so the `unless` never executes its body:

| input | expected | actual |
|---|---|---|
| `{}` | error | **passed through** |
| `{'connector_id' => ''}` | error | **passed through** |
| `{'connector_id' => '123'}` | pass | pass |

`create_app({})` silently POSTed an empty body. Corrected to `if !has_key? || value.empty?`.

### Verification

7 new examples. Against `master`, **3 fail** (symbol keys rejected; both `create_app` guard cases pass through). Full suite: 31 examples, 0 failures.

Includes an explicit test that symbol- and string-keyed calls produce a byte-identical request body, so the normalization can't drift.