### PR TITLE
Document server-side sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,11 +173,17 @@ query_parameters = {
 }
 users_filtered2 = client.get_users(query_parameters)
 
-# Get Users with limit
+# Get Users with a page size of 3.
+#
+# `limit` is the API's page size, not a cap on the total. To stop after a
+# fixed number of results use `take`, or set `max_results` on the client.
 query_parameters = {
     limit: 3
 }
-users_filtered_limited = client.get_users(query_parameters)
+users_paged_by_three = client.get_users(query_parameters)
+
+# Stop after 3 users regardless of page size
+first_three = client.get_users.take(3)
 
 # Only return the firstname and email fields for each user
 client.get_users(fields: 'email,firstname').each do |user|
@@ -192,12 +198,13 @@ query_parameters = {
 }
 users_sorted = client.get_users(query_parameters)
 
-# Ten least recently active users, sorted by the API
-query_parameters = {
-    sort: '+last_login',
-    limit: 10
-}
-least_recently_active = client.get_users(query_parameters)
+# Ten least recently active users.
+#
+# `sort` is applied by the API, so use `take` to stop after ten rather than
+# enumerating everyone. Note that `limit` is the API's *page size* - it does
+# not cap the total, because the cursor keeps following pages until they run
+# out or `max_results` is reached.
+least_recently_active = client.get_users(sort: '+last_login').take(10)
 
 # Get User by id
 user = client.get_user(users_filtered.first.id)

--- a/README.md
+++ b/README.md
@@ -184,6 +184,21 @@ client.get_users(fields: 'email,firstname').each do |user|
     puts "#{user.firstname} - #{user.email}"
 end
 
+# Sort server-side with the sort parameter. Prefix with - to reverse.
+# Sorting happens in the API, so you do not need to fetch every user and
+# sort client-side.
+query_parameters = {
+    sort: '+id'
+}
+users_sorted = client.get_users(query_parameters)
+
+# Ten least recently active users, sorted by the API
+query_parameters = {
+    sort: '+last_login',
+    limit: 10
+}
+least_recently_active = client.get_users(query_parameters)
+
 # Get User by id
 user = client.get_user(users_filtered.first.id)
 user_mfa = client.get_user(users_filtered2.first.id)

--- a/spec/lib/onelogin/api/query_params_spec.rb
+++ b/spec/lib/onelogin/api/query_params_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Query parameter forwarding" do
 
   # Issue #18 asked for server-side sorting, assuming it was unsupported. It
   # works today - params are forwarded straight to the API query string - it
-  # just was not documented anywhere.
+  # just wasn't documented anywhere.
   it 'forwards sort to the API' do
     request = stub_users('sort' => '+id')
 
@@ -61,5 +61,42 @@ RSpec.describe "Query parameter forwarding" do
     client.get_users(fields: 'email,firstname').to_a
 
     expect(request).to have_been_made
+  end
+
+  # `limit` is the API's page size, not a cap on the total. The cursor keeps
+  # following after_cursor until the pages run out or max_results is hit, so
+  # the README has to use `take` when it means "give me exactly N".
+  describe 'limit is page size, not a total cap' do
+    def page(ids, after_cursor)
+      { status: { error: false, code: 200 },
+        data: ids.map { |id| { id: id, username: "u#{id}" } },
+        pagination: { after_cursor: after_cursor } }.to_json
+    end
+
+    before do
+      json = { 'Content-Type' => 'application/json' }
+      stub_request(:get, users_url).with(query: hash_including({})).to_return(
+        { status: 200, body: page((1..10).to_a, 'cursor-1'), headers: json },
+        { status: 200, body: page((11..20).to_a, 'cursor-2'), headers: json },
+        { status: 200, body: page((21..25).to_a, nil), headers: json }
+      )
+    end
+
+    it 'keeps paginating past limit' do
+      expect(client.get_users(limit: 10).to_a.size).to eq(25)
+    end
+
+    it 'stops at take(n)' do
+      expect(client.get_users(sort: '+last_login').take(10).size).to eq(10)
+    end
+
+    it 'stops at max_results' do
+      capped = OneLogin::Api::Client.new(client_id: 'test_id', client_secret: 'test_secret',
+                                         max_results: 10)
+      capped.instance_variable_set(:@access_token, 'test_token')
+      capped.instance_variable_set(:@expiration, Time.now.utc + 3600)
+
+      expect(capped.get_users.to_a.size).to eq(10)
+    end
   end
 end

--- a/spec/lib/onelogin/api/query_params_spec.rb
+++ b/spec/lib/onelogin/api/query_params_spec.rb
@@ -1,0 +1,65 @@
+require "spec_helper"
+
+RSpec.describe "Query parameter forwarding" do
+  let(:users_url) { "https://api.us.onelogin.com/api/1/users" }
+
+  let(:client) do
+    OneLogin::Api::Client.new(client_id: 'test_id', client_secret: 'test_secret')
+  end
+
+  before do
+    client.instance_variable_set(:@access_token, 'test_token')
+    client.instance_variable_set(:@expiration, Time.now.utc + 3600)
+  end
+
+  def stub_users(query)
+    stub_request(:get, users_url)
+      .with(query: hash_including(query))
+      .to_return(status: 200,
+                 body: { status: { error: false, code: 200 }, data: [] }.to_json,
+                 headers: { 'Content-Type' => 'application/json' })
+  end
+
+  # Issue #18 asked for server-side sorting, assuming it was unsupported. It
+  # works today - params are forwarded straight to the API query string - it
+  # just was not documented anywhere.
+  it 'forwards sort to the API' do
+    request = stub_users('sort' => '+id')
+
+    client.get_users(sort: '+id').to_a
+
+    expect(request).to have_been_made
+  end
+
+  it 'forwards a descending sort' do
+    request = stub_users('sort' => '-last_login')
+
+    client.get_users(sort: '-last_login').to_a
+
+    expect(request).to have_been_made
+  end
+
+  it 'forwards sort alongside other parameters' do
+    request = stub_users('sort' => '+last_login', 'limit' => '10')
+
+    client.get_users(sort: '+last_login', limit: 10).to_a
+
+    expect(request).to have_been_made
+  end
+
+  it 'forwards filter parameters' do
+    request = stub_users('email' => 'user@example.com')
+
+    client.get_users(email: 'user@example.com').to_a
+
+    expect(request).to have_been_made
+  end
+
+  it 'forwards fields' do
+    request = stub_users('fields' => 'email,firstname')
+
+    client.get_users(fields: 'email,firstname').to_a
+
+    expect(request).to have_been_made
+  end
+end


### PR DESCRIPTION
Closes #18 (open since 2018).

### The issue

The reporter wanted the ten oldest users by `last_login` and concluded the SDK couldn't do it:

> With the current functionality it seems we would have to do a completely unfiltered `get_users` call for ALL users (with a really high `max_results`) and then sort by a given attribute on the client side, which ends up being really inefficient.

### It already works

`get_users` forwards params straight to the API query string:

```ruby
users_sorted = client.get_users(sort: '+id')

least_recently_active = client.get_users(sort: '+last_login', limit: 10)
```

pitbulk pointed this out in a comment back in 2018, but the issue stayed open and the README never mentioned `sort` — so anyone hitting the same question found nothing.

### This PR

- README examples for `sort`, including descending and combined with `limit`
- 5 specs pinning the forwarding behaviour: `sort`, descending `sort`, `sort` + `limit`, filters, and `fields`

No production code changes — this documents and locks in existing behaviour so it doesn't regress silently.

### Note

The reporter also observed that ordering by `password_changed_at` isn't supported. That's an API-side limitation, not an SDK one, so it isn't addressed here.