### PR TITLE
Set page size in the sorting example

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,11 +200,14 @@ users_sorted = client.get_users(query_parameters)
 
 # Ten least recently active users.
 #
-# `sort` is applied by the API, so use `take` to stop after ten rather than
-# enumerating everyone. Note that `limit` is the API's *page size* - it does
-# not cap the total, because the cursor keeps following pages until they run
-# out or `max_results` is reached.
-least_recently_active = client.get_users(sort: '+last_login').take(10)
+# `sort` is applied by the API. `limit` sets the page size so the request
+# itself only fetches ten rows, and `take` stops the cursor after ten so it
+# does not page any further.
+#
+# Use both: `limit` alone does not cap the total, because the cursor keeps
+# following pages until they run out or `max_results` is reached, and `take`
+# alone still transfers a full default-sized page and discards the extra.
+least_recently_active = client.get_users(sort: '+last_login', limit: 10).take(10)
 
 # Get User by id
 user = client.get_user(users_filtered.first.id)


### PR DESCRIPTION
Follow-up to #120. This commit was pushed to that branch moments after it merged, so it missed the merge — reapplying it here.

### What's on master today

```ruby
least_recently_active = client.get_users(sort: '+last_login').take(10)
```

That is **correct** — `take(10)` does stop the cursor after ten. It's just not efficient: without `limit`, the API returns its default page size and the SDK discards the surplus locally.

### Measured

Against a stubbed 50-row default page:

| | requests | rows transferred | yielded |
|---|---:|---:|---:|
| `take(10)` alone | 1 | **50** | 10 |
| `limit: 10` + `take(10)` | 1 | **10** | 10 |

Same request count, five times the payload.

### Why it matters here

Issue #18 was explicitly about efficiency:

> ...we would have to do a completely unfiltered `get_users` call for ALL users (with a really high `max_results`) and then sort by a given attribute on the client side, which ends up being really inefficient.

Recommending `take` without `limit` only half-answers that. The two parameters do different jobs and the example should show both:

- `limit` bounds **the request** (page size)
- `take` bounds **the pagination** (how many pages the cursor follows)

Neither alone does what the example claims. Raised by Copilot on #120.

README only — no code or spec changes. The three specs from #120 already pin these semantics.