### PR TITLE
Raise required_ruby_version to 3.2; test 3.2-3.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.0', '3.1', '3.2', '3.3']
+        ruby: ['3.2', '3.3', '3.4']
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -33,7 +33,14 @@ Or install it yourself as:
 
 ### Dependencies
 
+* Ruby >= 3.2
 * httparty
+* nokogiri
+
+Ruby 3.2 is the lowest version on which `nokogiri` resolves to a release with
+no known security advisories — below it, the newest installable `nokogiri` is
+still affected by a critical one. If you are on an older Ruby, `bundle install`
+will resolve to onelogin 1.7.0, the last release supporting it.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ Or install it yourself as:
 
 Ruby 3.2 is the lowest version on which `nokogiri` resolves to a release with
 no known security advisories — below it, the newest installable `nokogiri` is
-still affected by a critical one. If you are on an older Ruby, `bundle install`
-will resolve to onelogin 1.7.0, the last release supporting it.
+still affected by a critical one.
+
+On an older Ruby, `bundle install` resolves to the most recent release that
+still supports it rather than failing, so existing builds keep working. You
+just stop receiving updates until you upgrade Ruby.
 
 ## Getting started
 

--- a/onelogin.gemspec
+++ b/onelogin.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 3.2'
 
   spec.add_runtime_dependency('httparty', '>=0.13.7')
   spec.add_runtime_dependency('nokogiri', '>=1.6.3.1')


### PR DESCRIPTION
Closes #116.

### The declared floor was fiction

`required_ruby_version = '>= 1.9.3'` cannot be honoured by the gem's own runtime graph — the unbounded `nokogiri >= 1.6.3.1` resolves to a version needing Ruby >= 3.2.

But tidiness isn't the real argument. **Ruby 3.2 is the lowest version on which a consumer can install this gem and get a `nokogiri` with no known advisories:**

| Ruby | newest installable nokogiri | status |
|---|---|---|
| 2.7 | 1.15.7 | **critical unpatched** — [GHSA-353f-x4gh-cqq8](https://github.com/advisories/GHSA-353f-x4gh-cqq8) needs 1.18.9 |
| 3.0 | 1.17.2 | **critical unpatched** |
| 3.1 | 1.18.10 | high severity unpatched — [GHSA-c4rq-3m3g-8wgx](https://github.com/advisories/GHSA-c4rq-3m3g-8wgx) needs 1.19.3 |
| **3.2+** | **1.19.4** | **clean** |

Advertising support for Rubies where we can only ship a vulnerable parser isn't support.

### CI was testing the vulnerable configurations

The matrix was `['3.0', '3.1', '3.2', '3.3']` — three EOL versions (3.0 since Apr 2024, 3.1 since Mar 2025, 3.2 ~Mar 2026), and **3.4 was missing entirely** despite being current stable.

Now `['3.2', '3.3', '3.4']`.

### What existing users on older Rubies see

Verified against RubyGems' actual resolver behaviour, using `nokogiri` (which already has a 3.2 floor) on Ruby 3.0.6:

```
$ gem install nokogiri -v 1.19.4        # explicit version
ERROR: nokogiri-1.19.4 requires Ruby version >= 3.2, < 4.1.dev.
       The current ruby version is 3.0.6.216.

$ gem install nokogiri                  # unversioned
Successfully installed nokogiri-1.17.2
```

So after this ships, a Ruby 3.0 user running `bundle install` **resolves cleanly to onelogin 1.7.0** — the newest compatible release — rather than erroring. Only someone explicitly pinning the new version gets an error, and it tells them exactly why.

That's the correct outcome, and it's why this doesn't need a major bump. Precedent agrees: nokogiri itself raised its floor from 3.0 to 3.1 in a minor release (1.17 → 1.18).

### Verification

- Suite green on Ruby 3.0 (current) and 3.2 (new floor): 48 examples, 0 failures
- README dependency section updated with the floor and the reason

### Deliberately not included

Issue #116 also raised whether `nokogiri` and `httparty` should gain **upper bounds** (`'~> 1.6', '>= 1.6.3.1'`). That's a resolution change affecting existing consumers and deserves its own review, so I've left it out. Worth noting it remains a live risk: an unbounded `nokogiri >= 1.6.3.1` means a future nokogiri 2.0 can reach every downstream app unannounced.

Raising the Ruby floor does **not** by itself guarantee a patched nokogiri — it makes one *reachable*. A consumer pinning an old nokogiri in their own Gemfile can still resolve a vulnerable one. A `>= 1.18.9` floor would close that; happy to open it separately if wanted.