### PR TITLE
Point README links at main

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This SDK will let you execute all the API methods, version/1, described
 at https://developers.onelogin.com/api-docs/1/getting-started/dev-overview.
 
-The toolkit is hosted on github. You can download it from:
+The toolkit is hosted on GitHub. You can download it from:
 * Lastest release: https://github.com/onelogin/onelogin-ruby-sdk/releases/latest
 * Main repo: https://github.com/onelogin/onelogin-ruby-sdk/tree/main
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ at https://developers.onelogin.com/api-docs/1/getting-started/dev-overview.
 
 The toolkit is hosted on github. You can download it from:
 * Lastest release: https://github.com/onelogin/onelogin-ruby-sdk/releases/latest
-* Master repo: https://github.com/onelogin/onelogin-ruby-sdk/tree/master
+* Main repo: https://github.com/onelogin/onelogin-ruby-sdk/tree/main
 
 
 ## Support
@@ -556,4 +556,4 @@ The gem is available as open source under the terms of the [MIT License](http://
 
 ## Code of Conduct
 
-Everyone interacting in the OneLogin Ruby Sdk project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/onelogin/onelogin-ruby-sdk/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the OneLogin Ruby Sdk project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/onelogin/onelogin-ruby-sdk/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Follow-up to renaming the default branch `master` -> `main`.

Updates the only two `master` references in the repo:

- `tree/master` -> `tree/main` (and relabelled "Master repo" -> "Main repo")
- `blob/master/CODE_OF_CONDUCT.md` -> `blob/main/...`

GitHub redirects the old URLs indefinitely, so nothing was broken — but the links shouldn't depend on a redirect.

### Nothing else referenced master

Checked before the rename:

- Both workflows use bare `on: [push, pull_request]` with no branch filters, so CI was unaffected
- No branch protection rules, no rulesets, no GitHub Pages
- `onelogin.gemspec` has no branch-specific URLs