### PR TITLE
Release 1.8.0

### DIFF
--- a/lib/onelogin/version.rb
+++ b/lib/onelogin/version.rb
@@ -1,3 +1,3 @@
 module OneLogin
-  VERSION = "1.7.0"
+  VERSION = "1.8.0"
 end


### PR DESCRIPTION
Bumps `lib/onelogin/version.rb` to 1.8.0 so everything on `main` since 1.7.0 can be published.

### Fixed

- **Non-200 responses on paginated endpoints** (#4, open since 2017). A proxy or gateway error page arrives as `text/html`, so `parsed_response` returned a String and `Cursor` raised `NoMethodError: undefined method 'has_key?'` instead of `ApiException`. Also reports the real HTTP status rather than a hardcoded 500.
- **Symbol keys in parameter hashes** (#59, open since 2020). The README documents symbol keys, but the required-parameter guards looked them up as strings, so the documented call to `create_session_login_token` always failed. `to_json` already serialized both forms identically — only the validation disagreed, so the wire format is unchanged.
- **`create_app` validation never fired.** The guard read `unless has_key? || value.empty?`, which is true in every case. `create_app({})` silently POSTed an empty body.

### Added

- **`ApiException#code`.** The class stored `@code` but exposed no reader, so callers couldn't distinguish a 401 from a 429 — the exact thing #4 asked for.

### Changed — read this one

- **`required_ruby_version` raised from `>= 1.9.3` to `>= 3.2`** (#116).

  The old floor was unachievable: the unbounded `nokogiri >= 1.6.3.1` runtime dependency resolves to a version requiring Ruby >= 3.2. More importantly, **3.2 is the lowest Ruby on which a consumer gets a `nokogiri` with no known advisories** — below it the newest installable release still carries a critical one.

  Existing users on older Rubies are **not broken**. RubyGems' resolver filters by compatibility, so `bundle install` on Ruby 3.0 resolves to 1.7.0 rather than failing. Only an explicit pin to 1.8.0 errors, and the message says why.

  Minor rather than major follows nokogiri's own precedent (it raised 3.0 → 3.1 in 1.17 → 1.18).

### Documentation

- Server-side sorting documented (#18, open since 2018) — it always worked, it just appeared nowhere in the README
- `limit` clarified as API page size, not a result cap
- Support disclaimer (#107), events-to-csv `--limit` fix (#98)

### Housekeeping

- Removed the Rails 5.1.5 example app (EOL 2019) — took Dependabot alerts from 180 to 0 and cut the published package from 164 files to 58
- CI matrix now 3.2/3.3/3.4; `rake` dev dependency to `~> 13.0` (GHSA-jppv-gw3r-w3q8)
- Deleted dead `.travis.yml`; regenerated `examples/Gemfile.lock`

### Verification

- 48 examples, 0 failures on Ruby 3.2; CI green on 3.2/3.3/3.4
- Ruby 3.0 correctly refuses to resolve: `Ruby (>= 3.2) ... is not available in the local ruby installation`
- Package builds clean at 58 files, no `vendor/` or Rails example

### Publishing (manual — no release automation on this repo)

```
gem build onelogin.gemspec
gem push onelogin-1.8.0.gem --otp <code>
git tag -a v1.8.0 -m "Release 1.8.0" && git push origin v1.8.0
```